### PR TITLE
Cs 220 chore/jira 이슈 생성 시 task 만들어지도록 변경

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/chore-issue-form.yml
@@ -12,8 +12,8 @@ body:
         제목은 반드시 `Chore/ ~` 형식으로 작성해주세요.  
         예: `Chore/멀티모듈 SW 아키텍처 설계`
 
-  - type : input
-    id : parentKey
+  - type: input
+    id: parentKey
     attributes:
       label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
       description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'

--- a/.github/ISSUE_TEMPLATE/feat-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/feat-issue-form.yml
@@ -12,11 +12,11 @@ body:
         제목은 반드시 `Feat/ ~` 형식으로 작성해주세요.  
         예: `Feat/A 기능 구현`
 
-  - type : input
-    id : parentKey
+  - type: input
+    id: parentKey
     attributes:
-      label: '상위 직업 (Epic, 보라색 번개) Ticket Number'
-      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/fix-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/fix-issue-form.yml
@@ -12,11 +12,11 @@ body:
         제목은 반드시 `Fix/ ~` 형식으로 작성해주세요.  
         예: `Fix/A 기능 중 B 에러`
 
-  - type : input
-    id : parentKey
+  - type: input
+    id: parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/performance-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/performance-issue-form.yml
@@ -12,11 +12,11 @@ body:
         제목은 반드시 `Performance/ ~` 형식으로 작성해주세요.  
         예: `Performance/A 기능 성능 개선`
 
-  - type : input
-    id : parentKey
+  - type: input
+    id: parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/refactor-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/refactor-issue-form.yml
@@ -12,11 +12,11 @@ body:
         제목은 반드시 `Refactor/ ~` 형식으로 작성해주세요.  
         예: `Refactor/A 기능 리팩토링`
 
-  - type : input
-    id : parentKey
+  - type: input
+    id: parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/workflows/create-jira-chore-issue.yml
+++ b/.github/workflows/create-jira-chore-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 스토리
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-feat-issue.yml
+++ b/.github/workflows/create-jira-feat-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 스토리
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-fix-issue.yml
+++ b/.github/workflows/create-jira-fix-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-performance-issue.yml
+++ b/.github/workflows/create-jira-performance-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-refactor-issue.yml
+++ b/.github/workflows/create-jira-refactor-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
기존 story/subtask 체계에서 이슈 생성 시 jira에서 유형 상관없이 task만 생성되도록 햇습니

---

## 🔗 관련 이슈
- closes #8 

---

## 💡 추가 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - 이슈 템플릿의 라벨 및 설명에서 "Story(녹색 북마크)"를 "Epic(보라색 번개)"으로 변경하였고, 일부 한글 표현 및 문법을 개선하였습니다.
  - YAML 문법에서 콜론(:) 주변의 공백을 제거하여 형식을 통일하였습니다.

- **Chores**
  - Jira 이슈 생성 워크플로우에서 이슈 타입을 한글("스토리", "하위 작업")에서 영어("Task")로 변경하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->