### PR TITLE
Feat/#10

### DIFF
--- a/crawling/crawling_hitter.py
+++ b/crawling/crawling_hitter.py
@@ -1,0 +1,131 @@
+import logging
+from selenium import webdriver
+from selenium.webdriver.support.ui import Select
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from bs4 import BeautifulSoup
+import pymysql
+import time
+import os
+
+# 로깅 기본 설정
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+
+season = "2025"
+
+# 팀 코드 매핑
+teams = {
+    "HT": "KIA", "SS": "삼성", "LG": "LG", "OB": "두산",
+    "KT": "KT", "SK": "SSG", "LT": "롯데", "HH": "한화",
+    "NC": "NC", "WO": "키움"
+}
+
+def extractPlayers(driver):
+    soup = BeautifulSoup(driver.page_source, "html.parser")
+    table = soup.find("table", {"class": "tData01 tt"})
+    tbody = table.find("tbody")
+    players = []
+
+    for row in tbody.find_all("tr"):
+        cols = row.find_all("td")
+        if len(cols) < 16:
+            continue
+
+        try:
+            name = cols[1].text.strip()
+            avgText = cols[3].text.strip()
+            avg = None if avgText == '-' else float(avgText)
+
+            data = list(map(lambda x: int(x.replace(",", "")) if x.strip() else 0, [
+                cols[4].text, cols[5].text, cols[6].text, cols[7].text,
+                cols[8].text, cols[9].text, cols[10].text, cols[11].text,
+                cols[13].text, cols[14].text, cols[15].text
+            ]))
+
+            players.append((name, avg, *data))
+        except Exception as e:
+            logging.error(f"에러 발생: {e}")
+            continue
+
+    return players
+
+# DB 연결
+conn = pymysql.connect(
+	    host=os.getenv("DB_URL"),
+	    user=os.getenv("DB_USER"),
+	    password=os.getenv("DB_PASSWORD"),
+	    db=os.getenv("DB_NAME"),
+	    charset='utf8'
+	)
+cursor = conn.cursor()
+
+# 크롬 설정
+options = Options()
+options.add_argument("--headless")
+driver = webdriver.Chrome(options=options)
+wait = WebDriverWait(driver, 10)
+
+driver.get("https://www.koreabaseball.com/Record/Player/HitterBasic/Basic1.aspx")
+time.sleep(2)
+
+# 팀별 크롤링
+for teamId, (code, teamName) in enumerate(teams.items(), start=1):
+    logging.info(f"크롤링 중: {teamName} (teamID: {teamId})")
+    # 시즌 선택
+    seasonSelect = Select(driver.find_element(By.ID, "cphContents_cphContents_cphContents_ddlSeason_ddlSeason"))
+    seasonSelect.select_by_value(season)
+    time.sleep(5)
+    # 팀 선택
+    teamSelect = Select(driver.find_element(By.ID, "cphContents_cphContents_cphContents_ddlTeam_ddlTeam"))
+    teamSelect.select_by_value(code)
+    time.sleep(5)
+
+    # 페이지 1
+    players = extractPlayers(driver)
+
+    # 페이지 2 (있다면)
+    try:
+        page2Btn = wait.until(EC.element_to_be_clickable(
+            (By.ID, "cphContents_cphContents_cphContents_ucPager_btnNo2")))
+        page2Btn.click()
+        time.sleep(5)
+        players += extractPlayers(driver)
+    except Exception as e:
+        logging.warning(f"페이지 2 없음 또는 클릭 실패: {e}")
+        pass
+    
+    # DB 저장 (복합키로 upsert)
+    for p in players:
+        try:
+            cursor.execute("""
+                INSERT INTO hitter_info
+                    (name, avg, G, PA, AB, R, H, `2B`, `3B`, HR, RBI, SAC, SF, teamID, season)
+                VALUES
+                    (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON DUPLICATE KEY UPDATE
+                    avg=VALUES(avg), G=VALUES(G), PA=VALUES(PA), AB=VALUES(AB), R=VALUES(R),
+                    H=VALUES(H), `2B`=VALUES(`2B`), `3B`=VALUES(`3B`), HR=VALUES(HR),
+                    RBI=VALUES(RBI), SAC=VALUES(SAC), SF=VALUES(SF)
+            """, (*p, teamId, int(season)))
+        except Exception as e:
+            logging.error(f"DB 저장 에러: {e}")
+
+    conn.commit()
+
+    # 페이지 1로 돌아가기
+    try:
+        page1Btn = wait.until(EC.element_to_be_clickable(
+                (By.ID, "cphContents_cphContents_cphContents_ucPager_btnNo1")))
+        page1Btn.click()
+        time.sleep(5)
+    except Exception as e:
+        logging.warning(f"페이지 1로 돌아가기 실패: {e}")
+
+driver.quit()
+conn.close()
+logging.info("크롤링 및 저장 완료!")

--- a/crawling/crawling_hitter.py
+++ b/crawling/crawling_hitter.py
@@ -111,7 +111,7 @@ for teamId, (code, teamName) in enumerate(teams.items(), start=1):
         try:
             cursor.execute("""
                 INSERT INTO hitter_info
-                    (id, name, avg, G, PA, AB, R, H, `2B`, `3B`, HR, RBI, SAC, SF, teamID, season)
+                    (id, name, avg, G, PA, AB, R, H, `2B`, `3B`, HR, RBI, SAC, SF, team_id, season)
                 VALUES
                     (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON DUPLICATE KEY UPDATE

--- a/crawling/crawling_hitter.py
+++ b/crawling/crawling_hitter.py
@@ -29,7 +29,15 @@ teams = {
 def extractPlayers(driver):
     soup = BeautifulSoup(driver.page_source, "html.parser")
     table = soup.find("table", {"class": "tData01 tt"})
+    if table is None:
+        logging.error("통계 테이블을 찾지 못했습니다.")
+        return []
+
     tbody = table.find("tbody")
+    if tbody is None:
+        logging.error("테이블 본문(tbody)을 찾지 못했습니다.")
+        return []
+    
     players = []
 
     for row in tbody.find_all("tr"):
@@ -46,11 +54,14 @@ def extractPlayers(driver):
             avgText = cols[3].text.strip()
             avg = None if avgText == '-' else float(avgText)
 
-            data = list(map(lambda x: int(x.replace(",", "")) if x.strip() else 0, [
-                cols[4].text, cols[5].text, cols[6].text, cols[7].text,
-                cols[8].text, cols[9].text, cols[10].text, cols[11].text,
-                cols[13].text, cols[14].text, cols[15].text
-            ]))
+            def _to_int(text: str) -> int:
+                text = text.strip().replace(",", "")
+                return int(text) if text.isdigit() else 0
+            data = list(map(_to_int, [
+                 cols[4].text, cols[5].text, cols[6].text, cols[7].text,
+                 cols[8].text, cols[9].text, cols[10].text, cols[11].text,
+                 cols[13].text, cols[14].text, cols[15].text
+             ]))
 
             players.append((player_id, name, avg, *data))
         except Exception as e:

--- a/crawling/crawling_match.py
+++ b/crawling/crawling_match.py
@@ -124,17 +124,19 @@ for year in years:
 
                     # MySQL에 삽입
                     try:
-                        if away_score is not None and home_score is not None:
-                            cursor.execute("""
-                                INSERT INTO matches (home_team_id, away_team_id, match_date, created_at, home_score, away_score, start_time)
-                                VALUES (%s, %s, %s, %s, %s, %s, %s)
-                            """, (home_team_id, away_team_id, current_date, datetime.datetime.now(), home_score, away_score, time_info))
-                        else:
-                            cursor.execute("""
-                                INSERT INTO matches (home_team_id, away_team_id, match_date, created_at, start_time)
-                                VALUES (%s, %s, %s, %s, %s)
-                            """, (home_team_id, away_team_id, current_date, datetime.datetime.now(), time_info))
+                        cursor.execute("""
+                            INSERT INTO matches 
+                                (home_team_id, away_team_id, match_date, created_at, home_score, away_score, start_time)
+                            VALUES (%s, %s, %s, %s, %s, %s, %s)
+                            ON DUPLICATE KEY UPDATE
+                                home_score = VALUES(home_score),
+                                away_score = VALUES(away_score),
+                                start_time = VALUES(start_time),
+                                updated_at = NOW()
+                        """, (home_team_id, away_team_id, current_date, datetime.datetime.now(), home_score, away_score, time_info))
+
                         conn.commit()
+        
                         logging.info(f"경기 저장 완료: {current_date} {time_info} {away_team} vs {home_team} ({away_score}, {home_score})")
                     except Exception as e:
                         logging.error(f"[{year}년 {month}월] DB 오류: {e}", exc_info=True)

--- a/crawling/crawling_match.py
+++ b/crawling/crawling_match.py
@@ -1,0 +1,150 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import Select
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import pymysql
+import time
+import datetime
+import logging
+import os
+# 로깅 설정
+logging.basicConfig(
+    filename='kbo_crawler.log',
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)s:%(message)s'
+)
+
+years = [2025]
+
+url = "https://www.koreabaseball.com/Schedule/Schedule.aspx"
+
+options = webdriver.ChromeOptions()
+options.add_argument("--headless")
+options.add_argument("--no-sandbox")
+options.add_argument("--disable-dev-shm-usage")
+
+driver = webdriver.Chrome(options=options)
+wait = WebDriverWait(driver, 10)
+
+conn = pymysql.connect(
+	    host=os.getenv("DB_URL"),
+	    user=os.getenv("DB_USER"),
+	    password=os.getenv("DB_PASSWORD"),
+	    db=os.getenv("DB_NAME"),
+	    charset='utf8'
+	)
+cursor = conn.cursor()
+
+team_map = {
+    'KIA': 1, '삼성': 2, 'LG': 3, '두산': 4, 'KT': 5,
+    'SSG': 6, '롯데': 7, '한화': 8, 'NC': 9, '키움': 10
+}
+
+for year in years:
+    try:
+        driver.get(url)
+        wait.until(EC.presence_of_element_located((By.ID, "ddlYear")))
+
+        year_dropdown = Select(driver.find_element(By.ID, "ddlYear"))
+        year_dropdown.select_by_value(str(year))
+        time.sleep(2)
+
+        month_dropdown = Select(driver.find_element(By.ID, "ddlMonth"))
+        available_months = [opt.get_attribute("value") for opt in month_dropdown.options if opt.get_attribute("value").isdigit()]
+
+        for month in available_months:
+            try:
+                month_dropdown.select_by_value(month)
+                time.sleep(2)
+                rows = wait.until(EC.presence_of_all_elements_located((By.CSS_SELECTOR, "#tblScheduleList > tbody > tr")))
+
+                current_date = None
+
+                for row in rows:
+                    cols = row.find_elements(By.TAG_NAME, "td")
+                    if len(cols) < 8:
+                        continue
+
+                    # "데이터가 없습니다." 행은 건너뜀
+                    if any("데이터가 없습니다" in c.text for c in cols):
+                        continue
+
+                    # 날짜 추적 (첫 경기만 날짜 있음, 나머지는 이전값 사용)
+                    if 'day' in cols[0].get_attribute("class"):
+                        raw_date = cols[0].text.strip()  # 예: 04.01(화)
+                        date_str = f"{year}-{raw_date.split('(')[0].replace('.', '-')}"
+                        try:
+                            current_date = datetime.datetime.strptime(date_str, "%Y-%m-%d").strftime("%Y-%m-%d")
+                        except Exception as e:
+                            logging.warning(f"날짜 파싱 오류: {date_str}, {e}")
+                            continue
+                        # 시간, 경기정보는 그대로
+                        time_col_idx = 1
+                        play_col_idx = 2
+                    else:
+                        # 날짜 셀이 없으므로, 시간, 경기정보 인덱스가 하나씩 당겨짐
+                        time_col_idx = 0
+                        play_col_idx = 1
+
+                    # 시간 포맷 맞추기
+                    time_info = cols[time_col_idx].text.strip()
+                    if len(time_info) == 5: 
+                        time_info += ":00"
+                    elif len(time_info) == 0:
+                        time_info = "00:00:00"
+
+                    # 경기 정보 추출
+                    play_td = cols[play_col_idx]
+                    play_spans = play_td.find_elements(By.TAG_NAME, "span")
+
+                    # 팀명이 두 개 이상 있어야만 처리 (보통: [away, (점수), vs, (점수), home])
+                    if len(play_spans) < 3:
+                        continue
+
+                    away_team = play_spans[0].text.strip()
+                    home_team = play_spans[-1].text.strip()
+
+                    # 점수 추출 (있는 경우만)
+                    away_score, home_score = None, None
+                    if len(play_spans) >= 5:
+                        try:
+                            away_score = int(play_spans[1].text.strip())
+                            home_score = int(play_spans[3].text.strip())
+                        except Exception as e:
+                            logging.warning(f"점수 파싱 오류: {[span.text for span in play_spans]}, {e}")
+                            away_score = None
+                            home_score = None
+
+                    home_team_id = team_map.get(home_team)
+                    away_team_id = team_map.get(away_team)
+                    if home_team_id is None or away_team_id is None:
+                        logging.warning(f"팀 매핑 실패: away_team={away_team}, home_team={home_team}")
+                        continue
+
+                    # MySQL에 삽입
+                    try:
+                        if away_score is not None and home_score is not None:
+                            cursor.execute("""
+                                INSERT INTO matches (home_team_id, away_team_id, match_date, created_at, home_score, away_score, start_time)
+                                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                            """, (home_team_id, away_team_id, current_date, datetime.datetime.now(), home_score, away_score, time_info))
+                        else:
+                            cursor.execute("""
+                                INSERT INTO matches (home_team_id, away_team_id, match_date, created_at, start_time)
+                                VALUES (%s, %s, %s, %s, %s)
+                            """, (home_team_id, away_team_id, current_date, datetime.datetime.now(), time_info))
+                        conn.commit()
+                        logging.info(f"경기 저장 완료: {current_date} {time_info} {away_team} vs {home_team} ({away_score}, {home_score})")
+                    except Exception as e:
+                        logging.error(f"[{year}년 {month}월] DB 오류: {e}", exc_info=True)
+
+            except Exception as e:
+                logging.error(f"[{year}년 {month}월] 오류: {e}", exc_info=True)
+
+    except Exception as e:
+        logging.critical(f"[{year}년] 연도 변경 실패: {e}", exc_info=True)
+
+driver.quit()
+conn.close()
+logging.info("데이터 삽입 완료")

--- a/crawling/crawling_pitcher.py
+++ b/crawling/crawling_pitcher.py
@@ -1,0 +1,161 @@
+import logging
+import re
+from selenium import webdriver
+from selenium.webdriver.support.ui import Select
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from bs4 import BeautifulSoup
+import pymysql
+import time
+import os
+
+# 로깅 설정
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+
+# 팀 코드 매핑
+teams = {
+    "HT": "KIA", "SS": "삼성", "LG": "LG", "OB": "두산",
+    "KT": "KT", "SK": "SSG", "LT": "롯데", "HH": "한화",
+    "NC": "NC", "WO": "키움"
+}
+
+season = "2025"
+
+def extract_players(driver):
+    soup = BeautifulSoup(driver.page_source, "html.parser")
+    table = soup.find("table", {"class": "tData01 tt"})
+    tbody = table.find("tbody")
+    players = []
+
+    for row in tbody.find_all("tr"):
+        cols = row.find_all("td")
+        if len(cols) < 19:  # 컬럼 개수 확인
+            continue
+
+        try:
+            # 선수 ID 추출
+            profile_link = cols[1].find("a")["href"]
+            player_id = int(re.search(r'(\d+)$', profile_link).group(1))
+
+            # 기본 정보 추출
+            name = cols[1].text.strip()
+            era = float(cols[3].text.strip()) if cols[3].text.strip() != '-' else None
+            ip = convert_ip(cols[10].text.strip())
+            
+            # 숫자 데이터 추출
+            data = [
+                int(cols[i].text.strip().replace(",", "") or 0)
+                for i in [4,5,6,8,11,12,13,14,15,16,17]
+            ]
+            
+            # WHIP 처리
+            whip = float(cols[18].text.strip()) if cols[18].text.strip() != '-' else None
+
+            players.append((player_id, name, era, ip, whip, *data))
+            
+        except Exception as e:
+            logging.error(f"행 처리 오류: {str(e)}")
+            continue
+
+    return players
+
+def convert_ip(ip_str):
+    """이닝(IP) 값을 소수로 변환 (예: 19 1/3 → 19.333)"""
+    if not ip_str:
+        return 0.0
+    parts = ip_str.split()
+    total = 0.0
+    for part in parts:
+        if '/' in part:
+            numerator, denominator = map(int, part.split('/'))
+            total += numerator / denominator
+        else:
+            total += float(part)
+    return round(total, 3)
+
+# DB 연결
+conn = pymysql.connect(
+	    host=os.getenv("DB_URL"),
+	    user=os.getenv("DB_USER"),
+	    password=os.getenv("DB_PASSWORD"),
+	    db=os.getenv("DB_NAME"),
+	    charset='utf8'
+	)
+cursor = conn.cursor()
+
+# 크롬 설정
+options = Options()
+options.add_argument("--headless")
+driver = webdriver.Chrome(options=options)
+wait = WebDriverWait(driver, 10)
+
+driver.get("https://www.koreabaseball.com/Record/Player/PitcherBasic/Basic1.aspx")
+time.sleep(2)
+
+# 팀별 크롤링
+for team_id, (code, team_name) in enumerate(teams.items(), start=1):
+    logging.info(f"크롤링 중: {team_name} (teamID: {team_id})")
+
+    # 시즌 선택
+    season_select = Select(driver.find_element(By.ID, "cphContents_cphContents_cphContents_ddlSeason_ddlSeason"))
+    season_select.select_by_value(season)
+    time.sleep(3)
+
+    # 팀 선택
+    team_select = Select(driver.find_element(By.ID, "cphContents_cphContents_cphContents_ddlTeam_ddlTeam"))
+    team_select.select_by_value(code)
+    time.sleep(3)
+
+    # 데이터 추출
+    pitchers = extract_players(driver)
+
+    # 2페이지 처리
+    try:
+        page2_btn = wait.until(EC.element_to_be_clickable(
+            (By.ID, "cphContents_cphContents_cphContents_ucPager_btnNo2")))
+        page2_btn.click()
+        time.sleep(3)
+        pitchers += extract_players(driver)
+    except Exception as e:
+        logging.warning(f"페이지 2 처리 실패: {str(e)}")
+
+    # DB 저장
+    for p in pitchers:
+        try:
+            cursor.execute("""
+                INSERT INTO pitcher_info (
+                    id, name, era, ip, whip,
+                    g, w, l, hld, h, hr, bb, hbp, so, r, er,
+                    team_id, season
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, 
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON DUPLICATE KEY UPDATE
+                    era=VALUES(era),
+                    ip=VALUES(ip),
+                    whip=VALUES(whip),
+                    g=VALUES(g),
+                    w=VALUES(w),
+                    l=VALUES(l),
+                    hld=VALUES(hld),
+                    h=VALUES(h),
+                    hr=VALUES(hr),
+                    bb=VALUES(bb),
+                    hbp=VALUES(hbp),
+                    so=VALUES(so),
+                    r=VALUES(r),
+                    er=VALUES(er)
+            """, (*p, team_id, season))
+        except Exception as e:
+            logging.error(f"DB 저장 실패: {str(e)}")
+
+    conn.commit()
+
+driver.quit()
+conn.close()
+logging.info("크롤링 및 저장 완료!")

--- a/crawling/crawling_pitcher.py
+++ b/crawling/crawling_pitcher.py
@@ -48,10 +48,12 @@ def extract_players(driver):
             ip = convert_ip(cols[10].text.strip())
             
             # 숫자 데이터 추출
-            data = [
-                int(cols[i].text.strip().replace(",", "") or 0)
-                for i in [4,5,6,8,11,12,13,14,15,16,17]
-            ]
+            def _safe_int(text: str) -> int:
+                t = text.strip().replace(",", "")
+                return int(t) if t.isdigit() else 0
+
+            data = [_safe_int(cols[i].text) for i in
+            [4, 5, 6, 8, 11, 12, 13, 14, 15, 16, 17]]
             
             # WHIP 처리
             whip = float(cols[18].text.strip()) if cols[18].text.strip() != '-' else None
@@ -66,7 +68,7 @@ def extract_players(driver):
 
 def convert_ip(ip_str):
     """이닝(IP) 값을 소수로 변환 (예: 19 1/3 → 19.333)"""
-    if not ip_str:
+    if not ip_str or ip_str == '-':
         return 0.0
     parts = ip_str.split()
     total = 0.0


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 타자 데이터 크롤링
- [x] 투수 데이터 크롤링
- [x] 타자 및 투수 id 추출 후 DB 삽입

---

## ✏️ 작업 내용
![image](https://github.com/user-attachments/assets/5186c998-7f10-46e5-9651-ddb84089ebe9)
---

## 🔗 관련 이슈
- #10 

---

## 💡 추가 사항
타자 및 투수 정보 테이블에서 기존 pk 가 복합키 였는데, kbo 홈페이지 내에서 a태그로 감싸진 id를 발견하여 그 id 를 기준으로 pk 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - KBO 공식 웹사이트에서 타자, 투수, 경기 일정 및 결과 데이터를 자동으로 수집하는 크롤러 스크립트가 추가되었습니다.
    - 수집된 선수 및 경기 데이터는 MySQL 데이터베이스에 자동 저장 및 갱신됩니다.
    - 크롤링 및 데이터 저장 과정에서 상세한 로그가 기록되어 진행 상황과 오류를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->